### PR TITLE
Fix pathType issue in Kubernetes Ingress

### DIFF
--- a/020-k8s/kubernetes.md
+++ b/020-k8s/kubernetes.md
@@ -181,7 +181,7 @@ spec:
   - http:
       paths:
       - path: /MON_CHEMIN_UNIQUE(/|$)(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: devopsapi-svc


### PR DESCRIPTION
I have corrected an issue in the Ingress configuration (`ingress.k8s.yaml`).  
 
### **Problem:**  
- The `pathType: Prefix` does **not** support regular expressions.  
- The following configuration caused a **warning** and did not work properly:  
  ```yaml
  - path: /MON_CHEMIN_UNIQUE(/|$)(.*)
    pathType: Prefix
  ```
- Running `kubectl apply -f ingress.k8s.yaml` resulted in this error:  
  ```
  Warning: path /MON_CHEMIN_UNIQUE(/|$)(.*) cannot be used with pathType Prefix
  ```
>
### **Solution:**  
- I replaced `pathType: Prefix` with `pathType: ImplementationSpecific`, which **supports regex-based paths** and is recommended for advanced configurations with NGINX.
>
### **Test Results:**  
- ✅ `kubectl apply -f ingress.k8s.yaml` → No more warning  
- ✅ `kubectl get ingress` → Ingress is correctly configured  
>
### **Reference:**  
According to the **[official Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types)**, `pathType: Prefix` cannot handle regex, and `ImplementationSpecific` should be used instead.
>
**This fix improves compatibility and prevents errors.**  
Looking forward to your review! 🙌  